### PR TITLE
Implemented the finalized and waiting to be finalized pages

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -224,7 +224,7 @@
                         </div>
                     </div>
                     <div class="p-4 pt-8 border-gray-200 dark:border-gray-700">
-                        <a href="#" class="text-blue-600 hover:underline dark:text-blue-500">View Calendar</a>
+                        <a href="finalized-schedule.html" class="text-blue-600 hover:underline dark:text-blue-500">View Calendar</a>
                     </div>
                     <div class="p-4 border-t border-gray-200 dark:border-gray-700">
                         <div class="flex justify-between items-center">

--- a/dashboard.html
+++ b/dashboard.html
@@ -195,7 +195,7 @@
                         </div>
                     </div>
                     <div class="p-4 pt-8 border-gray-200 dark:border-gray-700">
-                        <a href="#" class="text-blue-600 hover:underline dark:text-blue-500">View Calendar</a>
+                        <a href="waiting-schedule.html" class="text-blue-600 hover:underline dark:text-blue-500">View Calendar</a>
                     </div>
                     <div class="p-4 border-t border-gray-200 dark:border-gray-700">
                         <div class="flex justify-between items-center">

--- a/finalized-schedule.html
+++ b/finalized-schedule.html
@@ -1,0 +1,613 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <title>Finalized Schedule</title>
+</head>
+
+<body>
+  <main>
+    <div class="m-8 p-8 w-full bg-white flex justify-right items-right">
+      <button data-drawer-target="logo-sidebar" data-drawer-toggle="logo-sidebar" aria-controls="logo-sidebar" type="button"
+        class="inline-flex items-center p-4 text-sm text-gray-500 rounded-lg sm:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600">
+        <span class="sr-only">Open sidebar</span>
+        <svg class="w-6 h-6" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+          <path clip-rule="evenodd" fill-rule="evenodd"
+            d="M2 4.75A.75.75 0 012.75 4h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 4.75zm0 10.5a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM2 10a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 10z">
+          </path>
+        </svg>
+      </button>
+    </div>
+
+    <aside id="logo-sidebar" class="fixed top-0 left-0 z-40 w-64 h-screen transition-transform -translate-x-full sm:translate-x-0" aria-label="Sidebar">
+      <div class="h-full px-3 py-4 overflow-y-auto bg-gray-50 dark:bg-gray-800">
+        <a href="dashboard.html" class="flex items-center ps-2.5 mb-5">
+          <img src="https://flowbite.com/docs/images/logo.svg" class="h-6 me-3 sm:h-7" alt="Flowbite Logo" />
+          <span class="self-center text-xl font-semibold whitespace-nowrap dark:text-white">1on1</span>
+        </a>
+        <ul class="space-y-2 font-medium">
+          <li class="pt-8">
+            <a type="button"
+              class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-full text-sm px-5 py-2.5 text-center inline-flex items-center">
+              Create Calendar
+              <svg class="rtl:rotate-180 w-3.5 h-3.5 ms-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
+                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5h12m0 0L9 1m4 4L9 9" />
+              </svg>
+            </a>
+          </li>
+          <li>
+            <a href="dashboard.html" class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+              <svg class="flex-shrink-0 w-5 h-5 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 22 21">
+                <path d="M16.975 11H10V4.025a1 1 0 0 0-1.066-.998 8.5 8.5 0 1 0 9.039 9.039.999.999 0 0 0-1-1.066h.002Z" />
+                <path d="M12.5 0c-.157 0-.311.01-.565.027A1 1 0 0 0 11 1.02V10h8.975a1 1 0 0 0 1-.935c.013-.188.028-.374.028-.565A8.51 8.51 0 0 0 12.5 0Z" />
+              </svg>
+              <span class="flex-1 ms-3 whitespace-nowrap">Dashboard</span>
+            </a>
+          </li>
+
+          <li>
+            <a href="contact.html" class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+              <svg class="flex-shrink-0 w-5 h-5 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18">
+                <path
+                  d="M14 2a3.963 3.963 0 0 0-1.4.267 6.439 6.439 0 0 1-1.331 6.638A4 4 0 1 0 14 2Zm1 9h-1.264A6.957 6.957 0 0 1 15 15v2a2.97 2.97 0 0 1-.184 1H19a1 1 0 0 0 1-1v-1a5.006 5.006 0 0 0-5-5ZM6.5 9a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9ZM8 10H5a5.006 5.006 0 0 0-5 5v2a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-2a5.006 5.006 0 0 0-5-5Z" />
+              </svg>
+              <span class="flex-1 ms-3 whitespace-nowrap">Contacts</span>
+            </a>
+          </li>
+          <li>
+            <a href="#" class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+              <svg class="flex-shrink-0 w-5 h-5 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M5 5V.13a2.96 2.96 0 0 0-1.293.749L.879 3.707A2.96 2.96 0 0 0 .13 5H5Z" />
+                <path
+                  d="M6.737 11.061a2.961 2.961 0 0 1 .81-1.515l6.117-6.116A4.839 4.839 0 0 1 16 2.141V2a1.97 1.97 0 0 0-1.933-2H7v5a2 2 0 0 1-2 2H0v11a1.969 1.969 0 0 0 1.933 2h12.134A1.97 1.97 0 0 0 16 18v-3.093l-1.546 1.546c-.413.413-.94.695-1.513.81l-3.4.679a2.947 2.947 0 0 1-1.85-.227 2.96 2.96 0 0 1-1.635-3.257l.681-3.397Z" />
+                <path
+                  d="M8.961 16a.93.93 0 0 0 .189-.019l3.4-.679a.961.961 0 0 0 .49-.263l6.118-6.117a2.884 2.884 0 0 0-4.079-4.078l-6.117 6.117a.96.96 0 0 0-.263.491l-.679 3.4A.961.961 0 0 0 8.961 16Zm7.477-9.8a.958.958 0 0 1 .68-.281.961.961 0 0 1 .682 1.644l-.315.315-1.36-1.36.313-.318Zm-5.911 5.911 4.236-4.236 1.359 1.359-4.236 4.237-1.7.339.341-1.699Z" />
+              </svg>
+              <span class="flex-1 ms-3 whitespace-nowrap">Sign Out</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </aside>
+
+    <div class="p-8 sm:ml-64">
+      <div class="text-left w-full border-b p-4 flex justify-between mb-4 items-center">
+        <h1 class="text-lg md:text-4xl"> 30 Minute Meeting 
+        <span class="inline-flex align-middle items-center bg-green-100 text-green-800 text-xs font-medium ml-2.5 px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+          <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+          Finalized
+        </span></h1>
+        <div class="flex items-center justify-center">
+          <a type="button" id="lastWeekButton" class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-full px-2 py-2 mr-1 "> <svg
+              class="w-5 h-5 text-white " aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 19-7-7 7-7" />
+            </svg> </a>
+          <a type="button" id="nextWeekButton" class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-full px-2 py-2 "> <svg
+              class="w-5 h-5 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 5 7 7-7 7" />
+            </svg> </a>
+        </div>
+      </div>
+      <div class="table-container flex justify-center">
+        <table class="divide-y divide-gray-200 border border-gray-200 shadow-xl sm:rounded-lg min-w-full">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Time
+              </th>
+              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Sun 9
+              </th>
+              <th scope="col" class="px-3  py-3  text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Mon 10
+              </th>
+              <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Tue 11
+              </th>
+              <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Wed 12
+              </th>
+              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200  border border-gray-300">
+                Thu 13
+              </th>
+              <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Fri 14
+              </th>
+              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Sat 15
+              </th>
+            </tr>
+          </thead>
+          <tbody class="bg-white">
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                9:00 AM</td>
+              <td rowspan="2" data-popover-target="jim-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Sun 9">Jim</td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Mon 10"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Tue 11"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Wed 12"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Thu 13"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Fri 14"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Sat 15"></td>
+            </tr>
+            <div data-popover id="jim-popover" role="tooltip"
+              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Jim</h3>
+              </div>
+              <div class="px-3 py-2">
+                <p><b>Sunday, February 9th @9AM-10AM</b></p>
+                <p>Notes: Prepare slides before this meeting.</p>
+              </div>
+              <div data-popper-arrow></div>
+            </div>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Mon 10"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Tue 11"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Wed 12"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Thu 13"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Fri 14"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Sat 15"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                10:00 AM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                11:00 AM
+              </td>
+              <td rowspan="2" data-popover-target="peter-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Peter</td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <div data-popover id="peter-popover" role="tooltip"
+              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Peter</h3>
+              </div>
+              <div class="px-3 py-2">
+                <p><b>Sunday, February 9th @11AM-12PM</b></p>
+                <p>Notes: Prepare slides before this meeting.</p>
+              </div>
+              <div data-popper-arrow></div>
+            </div>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                12:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                1:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td rowspan="2" data-popover-target="neil-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Neil</td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <div data-popover id="neil-popover" role="tooltip"
+              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Neil</h3>
+              </div>
+              <div class="px-3 py-2">
+                <p><b>Sunday, February 14th @1PM-2PM</b></p>
+                <p>Notes: Prepare slides before this meeting.</p>
+              </div>
+              <div data-popper-arrow></div>
+            </div>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                2:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                3:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                4:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                5:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td rowspan="2" data-popover-target="bonnie-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Bonnie</td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <div data-popover id="bonnie-popover" role="tooltip"
+              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Bonnie</h3>
+              </div>
+              <div class="px-3 py-2">
+                <p><b>Thursday, February 13th @5PM-6PM</b></p>
+                <p>Notes: Prepare slides before this meeting.</p>
+              </div>
+              <div data-popper-arrow></div>
+            </div>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                6:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                7:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                8:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                9:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                10:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                11:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h1 class="text-lg md:text-4xl mt-10 border-b p-4">Invited Users:</h1>
+      <div id="selectedContacts" class="mt-4 flex flex-col justify-center">
+        <ul role="list" class="max-w-sm divide-y divide-gray-200 dark:divide-gray-700 mx-auto">
+          <li class="py-3 sm:py-4">
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <div class="flex-shrink-0">
+                <img class="w-8 h-8 rounded-full" src="media/profile.jpg" alt="Neil image">
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-gray-900 truncate dark:text-white">
+                  Jim Love
+                </p>
+                <p class="text-sm text-gray-500 truncate dark:text-gray-400">
+                  jim.love@gmail.com
+                </p>
+              </div>
+              <div class="flex flex-col space-y-2">
+                <span class="inline-flex items-center bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+                  <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+                  Confirmed
+                </span>
+              </div>
+            </div>
+          </li>
+          <li class="py-3 sm:py-4">
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <div class="flex-shrink-0">
+                <img class="w-8 h-8 rounded-full" src="media/profile.jpg" alt="Neil image">
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-gray-900 truncate dark:text-white">
+                  Peter Parker
+                </p>
+                <p class="text-sm text-gray-500 truncate dark:text-gray-400">
+                  peter.parker@spiderman.web
+                </p>
+              </div>
+              <div class="flex flex-col space-y-2">
+                <span class="inline-flex items-center bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+                  <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+                  Confirmed
+                </span>
+              </div>
+            </div>
+          </li>
+          <li class="py-3 sm:py-4">
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <div class="flex-shrink-0">
+                <img class="w-8 h-8 rounded-full" src="media/profile.jpg" alt="Neil image">
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-gray-900 truncate dark:text-white">
+                  Neil Sims
+                </p>
+                <p class="text-sm text-gray-500 truncate dark:text-gray-400">
+                  neil.sims@gmail.com
+                </p>
+              </div>
+              <span class="inline-flex items-center bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+                <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+                Confirmed
+              </span>
+            </div>
+          </li>
+          <li class="py-3 sm:py-4">
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <div class="flex-shrink-0">
+                <img class="w-8 h-8 rounded-full" src="media/profile.jpg" alt="Neil image">
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-gray-900 truncate dark:text-white">
+                  Bonnie Green
+                </p>
+                <p class="text-sm text-gray-500 truncate dark:text-gray-400">
+                  bonnie.green@gmail.com
+                </p>
+              </div>
+              <div class="flex flex-col space-y-2">
+                <span class="inline-flex items-center bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+                  <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+                  Confirmed
+                </span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+    </div>
+  </main>
+  <footer class="bg-white rounded-lg dark:bg-gray-900 p-8 sm:ml-64">
+    <div class="w-full max-w-screen-xl mx-auto p-4 md:py-8">
+      <hr class="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8" />
+      <span class="block text-sm text-gray-500 sm:text-center dark:text-gray-400">©
+        2024 <a href="#" class="hover:underline">1on1™</a>. All Rights
+        Reserved.</span>
+    </div>
+  </footer>
+</body>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js"></script>
+<script src="calendar.js"></script>
+<script>
+  function sendReminder(name) {
+    alert("Reminder sent to " + name);
+  }
+
+</script>
+
+</html>

--- a/finalized-schedule.html
+++ b/finalized-schedule.html
@@ -35,7 +35,7 @@
         </a>
         <ul class="space-y-2 font-medium">
           <li class="pt-8">
-            <a type="button"
+            <a type="button" href="calendar.html"
               class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-full text-sm px-5 py-2.5 text-center inline-flex items-center">
               Create Calendar
               <svg class="rtl:rotate-180 w-3.5 h-3.5 ms-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">

--- a/waiting-schedule.html
+++ b/waiting-schedule.html
@@ -82,13 +82,13 @@
     </aside>
 
     <div class="p-8 sm:ml-64">
-      <div class="text-left w-full border-b p-4 flex justify-between mb-4 items-center">
-        <h1 class="text-lg md:text-4xl"> 30 Minute Meeting
+      <div class="text-left w-full p-4 flex justify-between mb-4 items-center">
+        <h3 class="text-lg md:text-3xl"> 30 Minute Meeting
         <span class="inline-flex align-middle items-center bg-yellow-100 text-yellow-800 text-xs font-medium ml-2.5 px-2.5 py-0.5 rounded-full">
           <span class="w-2 h-2 me-1 bg-yellow-500 rounded-full"></span>
           Waiting to Finalize
         </span>
-        </h1>
+        </h3>
         <div class="flex items-center justify-center">
           <a type="button" id="lastWeekButton" class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-full px-2 py-2 mr-1 ">
             <svg class="w-5 h-5 text-white " aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -100,6 +100,37 @@
             </svg> </a>
         </div>
       </div>
+
+      <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
+        <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="default-tab" data-tabs-toggle="#default-tab-content" role="tablist">
+          <li class="me-2" role="presentation">
+            <button class="inline-block p-4 border-b-2 rounded-t-lg" id="profile-tab" data-tabs-target="#profile" type="button" role="tab" aria-controls="profile" aria-selected="true">Option 1</button>
+          </li>
+          <li class="me-2" role="presentation">
+            <button class="inline-block p-4 border-b-2 rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" id="dashboard-tab" data-tabs-target="#dashboard" type="button"
+              role="tab" aria-controls="dashboard" aria-selected="false">Option 2</button>
+          </li>
+          <li class="me-2" role="presentation">
+            <button class="inline-block p-4 border-b-2 rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" id="settings-tab" data-tabs-target="#settings" type="button"
+              role="tab" aria-controls="settings" aria-selected="false">Option 3</button>
+          </li>
+        </ul>
+      </div>
+      <div id="default-tab-content">
+        <div class="hidden p-4 rounded-lg bg-gray-50 dark:bg-gray-800" id="profile" role="tabpanel" aria-labelledby="profile-tab">
+          <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Profile tab's associated content</strong>.
+            Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        </div>
+        <div class="hidden p-4 rounded-lg bg-gray-50 dark:bg-gray-800" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab">
+          <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Dashboard tab's associated content</strong>.
+            Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        </div>
+        <div class="hidden p-4 rounded-lg bg-gray-50 dark:bg-gray-800" id="settings" role="tabpanel" aria-labelledby="settings-tab">
+          <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Settings tab's associated content</strong>.
+            Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        </div>
+      </div>
+
       <div class="table-container flex justify-center">
         <table class="divide-y divide-gray-200 border border-gray-200 shadow-xl sm:rounded-lg min-w-full">
           <thead class="bg-gray-50">

--- a/waiting-schedule.html
+++ b/waiting-schedule.html
@@ -35,7 +35,7 @@
         </a>
         <ul class="space-y-2 font-medium">
           <li class="pt-8">
-            <a type="button"
+            <a type="button" href="calendar.html"
               class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-full text-sm px-5 py-2.5 text-center inline-flex items-center">
               Create Calendar
               <svg class="rtl:rotate-180 w-3.5 h-3.5 ms-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
@@ -100,496 +100,1438 @@
             </svg> </a>
         </div>
       </div>
+      <p class="pl-4">Suggested Calendars:</p>
 
       <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
-        <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="default-tab" data-tabs-toggle="#default-tab-content" role="tablist">
+        <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="suggested-calendars" data-tabs-toggle="#suggested-calendars-content" role="tablist">
           <li class="me-2" role="presentation">
-            <button class="inline-block p-4 border-b-2 rounded-t-lg" id="profile-tab" data-tabs-target="#profile" type="button" role="tab" aria-controls="profile" aria-selected="true">Option 1</button>
+            <button class="inline-block p-4 border-b-2 rounded-t-lg" id="calendar1-tab" data-tabs-target="#calendar1" type="button" role="tab" aria-controls="profile" aria-selected="true">Option 1</button>
           </li>
           <li class="me-2" role="presentation">
-            <button class="inline-block p-4 border-b-2 rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" id="dashboard-tab" data-tabs-target="#dashboard" type="button"
+            <button class="inline-block p-4 border-b-2 rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" id="calendar2-tab" data-tabs-target="#calendar2" type="button"
               role="tab" aria-controls="dashboard" aria-selected="false">Option 2</button>
           </li>
           <li class="me-2" role="presentation">
-            <button class="inline-block p-4 border-b-2 rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" id="settings-tab" data-tabs-target="#settings" type="button"
+            <button class="inline-block p-4 border-b-2 rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" id="calendar3-tab" data-tabs-target="#calendar3" type="button"
               role="tab" aria-controls="settings" aria-selected="false">Option 3</button>
           </li>
         </ul>
       </div>
-      <div id="default-tab-content">
-        <div class="hidden p-4 rounded-lg bg-gray-50 dark:bg-gray-800" id="profile" role="tabpanel" aria-labelledby="profile-tab">
-          <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Profile tab's associated content</strong>.
-            Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+      <div id="suggested-calendars-content">
+        <div class="hidden rounded-lg" id="calendar1" role="tabpanel" aria-labelledby="calendar1-tab">
+        <!-- ######################################################################################################################## -->
+          <!-- Suggested Calendar #1  #} -->
+          <div class="table-container flex justify-center">
+            <table class="divide-y divide-gray-200 border border-gray-200 shadow-xl sm:rounded-lg min-w-full">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Time
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Sun 9
+                  </th>
+                  <th scope="col" class="px-3  py-3  text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Mon 10
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Tue 11
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Wed 12
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200  border border-gray-300">
+                    Thu 13
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Fri 14
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Sat 15
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="bg-white">
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    9:00 AM</td>
+                  <td rowspan="2" data-popover-target="jim-popover-1" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM"
+                    data-date="Sun 9">Jim</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Mon 10"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Tue 11"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Wed 12"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Thu 13"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Fri 14"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Sat 15"></td>
+                </tr>
+                <div data-popover id="jim-popover-1" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Jim</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Sunday, February 9th @9AM-10AM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Mon 10"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Tue 11"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Wed 12"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Thu 13"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Fri 14"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Sat 15"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    10:00 AM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    11:00 AM
+                  </td>
+                  <td rowspan="2" data-popover-target="peter-popover-1" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Peter</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="peter-popover-1" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Peter</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Sunday, February 9th @11AM-12PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    12:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    1:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td rowspan="2" data-popover-target="neil-popover-1" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Neil</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="neil-popover-1" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Neil</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Sunday, February 14th @1PM-2PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    2:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    3:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    4:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    5:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td rowspan="2" data-popover-target="bonnie-popover-1" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Bonnie</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="bonnie-popover-1" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Bonnie</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Thursday, February 13th @5PM-6PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    6:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    7:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    8:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    9:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    10:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    11:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        <!-- ################################################ END OF CALENDAR #1 ################################################### -->
         </div>
-        <div class="hidden p-4 rounded-lg bg-gray-50 dark:bg-gray-800" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab">
-          <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Dashboard tab's associated content</strong>.
-            Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        <div class="hidden rounded-lg" id="calendar2" role="tabpanel" aria-labelledby="calendar2-tab">
+          <!-- ############################################### START OF CALENDAR #2 ######################################################################### -->
+          <!-- Suggested Calendar #2  #} -->
+          <div class="table-container flex justify-center">
+            <table class="divide-y divide-gray-200 border border-gray-200 shadow-xl sm:rounded-lg min-w-full">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Time
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Sun 9
+                  </th>
+                  <th scope="col" class="px-3  py-3  text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Mon 10
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Tue 11
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Wed 12
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200  border border-gray-300">
+                    Thu 13
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Fri 14
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Sat 15
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="bg-white">
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    9:00 AM</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td rowspan="2" data-popover-target="jim-popover-2" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Jim</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="jim-popover-2" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Jim</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Thursday, February 13th @9AM-10AM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Mon 10"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Tue 11"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Wed 12"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Thu 13"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Fri 14"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Sat 15"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    10:00 AM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    11:00 AM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td rowspan="2" data-popover-target="peter-popover-2" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Peter</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="peter-popover-2" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Peter</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Monday, February 1th @11AM-12PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    12:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    1:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td rowspan="2" data-popover-target="neil-popover-2" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Neil</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="neil-popover-2" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Neil</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Sunday, February 14th @1PM-2PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    2:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    3:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    4:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    5:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td rowspan="2" data-popover-target="bonnie-popover-2" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Bonnie</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="bonnie-popover-2" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Bonnie</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Thursday, February 13th @5PM-6PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    6:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    7:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    8:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    9:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    10:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    11:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <!-- ################################################ END OF CALENDAR #2 ################################################### -->
         </div>
-        <div class="hidden p-4 rounded-lg bg-gray-50 dark:bg-gray-800" id="settings" role="tabpanel" aria-labelledby="settings-tab">
-          <p class="text-sm text-gray-500 dark:text-gray-400">This is some placeholder content the <strong class="font-medium text-gray-800 dark:text-white">Settings tab's associated content</strong>.
-            Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to control the content visibility and styling.</p>
+        <div class="hidden rounded-lg" id="calendar3" role="tabpanel" aria-labelledby="calendar3-tab">
+          <!-- ################################################# START OF CALENDAR #3 ###################################################################### -->
+          <div class="table-container flex justify-center">
+            <table class="divide-y divide-gray-200 border border-gray-200 shadow-xl sm:rounded-lg min-w-full">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Time
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Sun 9
+                  </th>
+                  <th scope="col" class="px-3  py-3  text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Mon 10
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Tue 11
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Wed 12
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200  border border-gray-300">
+                    Thu 13
+                  </th>
+                  <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Fri 14
+                  </th>
+                  <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                    Sat 15
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="bg-white">
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    9:00 AM</td>
+                  <td rowspan="2" data-popover-target="jim-popover-3" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM"
+                    data-date="Sun 9">Jim</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Mon 10"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Tue 11"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Wed 12"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Thu 13"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Fri 14"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Sat 15"></td>
+                </tr>
+                <div data-popover id="jim-popover-3" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Jim</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Sunday, February 9th @9AM-10AM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Mon 10"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Tue 11"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Wed 12"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Thu 13"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Fri 14"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Sat 15"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    10:00 AM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    11:00 AM
+                  </td>
+                  <td rowspan="2" data-popover-target="peter-popover-3" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Peter</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="peter-popover-3" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Peter</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Sunday, February 9th @11AM-12PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    12:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    1:00 PM
+                  </td>
+                  <td rowspan="2" data-popover-target="neil-popover-3" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Neil</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="neil-popover-3" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Neil</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Sunday, February 9th @1PM-2PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    2:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    3:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    4:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    5:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td rowspan="2" data-popover-target="bonnie-popover-3" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Bonnie</td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <div data-popover id="bonnie-popover-3" role="tooltip"
+                  class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+                  <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Bonnie</h3>
+                  </div>
+                  <div class="px-3 py-2">
+                    <p><b>Thursday, February 13th @5PM-6PM</b></p>
+                    <p>Notes: Prepare slides before this meeting.</p>
+                    <div>
+                      <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                      <select id="category"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                        <option selected="">Select Time</option>
+                        <option value="TV">Feb.10th @11AM-12PM</option>
+                        <option value="PC">Feb.11th @9AM-10AM</option>
+                        <option value="GA">Feb.12th @9AM-10AM</option>
+                      </select>
+                    </div>
+                    <a href="waiting-schedule.html" type="button" id="continueButton"
+                      class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                    </a>
+                  </div>
+                  <div data-popper-arrow></div>
+                </div>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    6:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    7:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    8:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    9:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    10:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+          
+                <tr>
+                  <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                    11:00 PM
+                  </td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+                <tr>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                  <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <!-- ################################################ END OF CALENDAR #3 ################################################### -->
         </div>
       </div>
 
-      <div class="table-container flex justify-center">
-        <table class="divide-y divide-gray-200 border border-gray-200 shadow-xl sm:rounded-lg min-w-full">
-          <thead class="bg-gray-50">
-            <tr>
-              <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
-                Time
-              </th>
-              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
-                Sun 9
-              </th>
-              <th scope="col" class="px-3  py-3  text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
-                Mon 10
-              </th>
-              <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
-                Tue 11
-              </th>
-              <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
-                Wed 12
-              </th>
-              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200  border border-gray-300">
-                Thu 13
-              </th>
-              <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
-                Fri 14
-              </th>
-              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
-                Sat 15
-              </th>
-            </tr>
-          </thead>
-          <tbody class="bg-white">
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                9:00 AM</td>
-              <td rowspan="2" data-popover-target="jim-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM"
-                data-date="Sun 9">Jim</td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Mon 10"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Tue 11"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Wed 12"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Thu 13"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Fri 14"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Sat 15"></td>
-            </tr>
-            <div data-popover id="jim-popover" role="tooltip"
-              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
-              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
-                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Jim</h3>
-              </div>
-              <div class="px-3 py-2">
-                <p><b>Sunday, February 9th @9AM-10AM</b></p>
-                <p>Notes: Prepare slides before this meeting.</p>
-                <div>
-                  <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
-                  <select id="category"
-                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
-                    <option selected="">Select Time</option>
-                    <option value="TV">Feb.10th @11AM-12PM</option>
-                    <option value="PC">Feb.11th @9AM-10AM</option>
-                    <option value="GA">Feb.12th @9AM-10AM</option>
-                  </select>
-                </div>
-                <a href="waiting-schedule.html" type="button" id="continueButton"
-                  class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
-                </a>
-              </div>
-              <div data-popper-arrow></div>
-            </div>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Mon 10"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Tue 11"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Wed 12"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Thu 13"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Fri 14"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Sat 15"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                10:00 AM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                11:00 AM
-              </td>
-              <td rowspan="2" data-popover-target="peter-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Peter</td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <div data-popover id="peter-popover" role="tooltip"
-              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
-              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
-                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Peter</h3>
-              </div>
-              <div class="px-3 py-2">
-                <p><b>Sunday, February 9th @11AM-12PM</b></p>
-                <p>Notes: Prepare slides before this meeting.</p>
-                <div>
-                  <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
-                  <select id="category"
-                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
-                    <option selected="">Select Time</option>
-                    <option value="TV">Feb.10th @11AM-12PM</option>
-                    <option value="PC">Feb.11th @9AM-10AM</option>
-                    <option value="GA">Feb.12th @9AM-10AM</option>
-                  </select>
-                </div>
-                <a href="waiting-schedule.html" type="button" id="continueButton"
-                  class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
-                </a>
-              </div>
-              <div data-popper-arrow></div>
-            </div>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                12:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                1:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td rowspan="2" data-popover-target="neil-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Neil</td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <div data-popover id="neil-popover" role="tooltip"
-              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
-              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
-                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Neil</h3>
-              </div>
-              <div class="px-3 py-2">
-                <p><b>Sunday, February 14th @1PM-2PM</b></p>
-                <p>Notes: Prepare slides before this meeting.</p>
-                <div>
-                  <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
-                  <select id="category"
-                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
-                    <option selected="">Select Time</option>
-                    <option value="TV">Feb.10th @11AM-12PM</option>
-                    <option value="PC">Feb.11th @9AM-10AM</option>
-                    <option value="GA">Feb.12th @9AM-10AM</option>
-                  </select>
-                </div>
-                <a href="waiting-schedule.html" type="button" id="continueButton"
-                  class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
-                </a>
-              </div>
-              <div data-popper-arrow></div>
-            </div>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                2:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                3:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                4:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                5:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td rowspan="2" data-popover-target="bonnie-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Bonnie</td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <div data-popover id="bonnie-popover" role="tooltip"
-              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
-              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
-                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Bonnie</h3>
-              </div>
-              <div class="px-3 py-2">
-                <p><b>Thursday, February 13th @5PM-6PM</b></p>
-                <p>Notes: Prepare slides before this meeting.</p>
-                <div>
-                  <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
-                  <select id="category"
-                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
-                    <option selected="">Select Time</option>
-                    <option value="TV">Feb.10th @11AM-12PM</option>
-                    <option value="PC">Feb.11th @9AM-10AM</option>
-                    <option value="GA">Feb.12th @9AM-10AM</option>
-                  </select>
-                </div>
-                <a href="waiting-schedule.html" type="button" id="continueButton"
-                  class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
-                </a>
-              </div>
-              <div data-popper-arrow></div>
-            </div>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                6:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                7:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                8:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                9:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                10:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-
-            <tr>
-              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
-                11:00 PM
-              </td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-            <tr>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
+      
       <div class="flex justify-center">
-        <a href="dashboard.html" type="button" id="continueButton"
-          class="mt-8 focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Finalize
-        </a>
+        <button id="successButton" data-modal-target="successModal" data-modal-toggle="successModal"
+          class="mt-8 text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+          type="button">
+          Finalize Calendar
+        </button>
+      </div>
+      <!-- Success modal -->
+      <div id="successModal" tabindex="-1" aria-hidden="true"
+        class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-modal md:h-full">
+        <div class="relative p-4 w-full max-w-md h-full md:h-auto">
+          <!-- Modal content -->
+          <div class="relative p-4 text-center bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5">
+            <button type="button"
+              class="text-gray-400 absolute top-2.5 right-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
+              data-modal-toggle="successModal">
+              <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd"
+                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                  clip-rule="evenodd"></path>
+              </svg>
+              <span class="sr-only">Close modal</span>
+            </button>
+            <div class="w-12 h-12 rounded-full bg-green-100 dark:bg-green-900 p-2 flex items-center justify-center mx-auto mb-3.5">
+              <svg aria-hidden="true" class="w-8 h-8 text-green-500 dark:text-green-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
+              </svg>
+              <span class="sr-only">Success</span>
+            </div>
+            <p class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Successfully finalized calendar!</p>
+            <button id="continue-button" data-modal-toggle="successModal" type="button"
+              class="py-2 px-3 text-sm font-medium text-center text-white rounded-lg bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-900">
+              Continue
+            </button>
+          </div>
+        </div>
       </div>
 
       <h1 class="text-lg md:text-4xl mt-10 border-b p-4">Invited Users:</h1>
@@ -698,6 +1640,10 @@
   function sendReminder(name) {
     alert("Reminder sent to " + name);
   }
+
+  document.getElementById('continue-button').addEventListener('click', function () {
+      window.location.href = 'finalized-schedule.html';
+    });
 
 </script>
 

--- a/waiting-schedule.html
+++ b/waiting-schedule.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Raleway&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <title>Finalized Schedule</title>
+  <title>Waiting to Finalize Schedule</title>
 </head>
 
 <body>
@@ -84,10 +84,10 @@
     <div class="p-8 sm:ml-64">
       <div class="text-left w-full border-b p-4 flex justify-between mb-4 items-center">
         <h1 class="text-lg md:text-4xl"> 30 Minute Meeting
-          <span class="inline-flex align-middle items-center bg-green-100 text-green-800 text-xs font-medium ml-2.5 px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
-            <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
-            Finalized
-          </span>
+        <span class="inline-flex align-middle items-center bg-yellow-100 text-yellow-800 text-xs font-medium ml-2.5 px-2.5 py-0.5 rounded-full">
+          <span class="w-2 h-2 me-1 bg-yellow-500 rounded-full"></span>
+          Waiting to Finalize
+        </span>
         </h1>
         <div class="flex items-center justify-center">
           <a type="button" id="lastWeekButton" class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-full px-2 py-2 mr-1 ">
@@ -151,6 +151,19 @@
               <div class="px-3 py-2">
                 <p><b>Sunday, February 9th @9AM-10AM</b></p>
                 <p>Notes: Prepare slides before this meeting.</p>
+                <div>
+                  <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                  <select id="category"
+                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                    <option selected="">Select Time</option>
+                    <option value="TV">Feb.10th @11AM-12PM</option>
+                    <option value="PC">Feb.11th @9AM-10AM</option>
+                    <option value="GA">Feb.12th @9AM-10AM</option>
+                  </select>
+                </div>
+                <a href="waiting-schedule.html" type="button" id="continueButton"
+                  class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                </a>
               </div>
               <div data-popper-arrow></div>
             </div>
@@ -205,6 +218,19 @@
               <div class="px-3 py-2">
                 <p><b>Sunday, February 9th @11AM-12PM</b></p>
                 <p>Notes: Prepare slides before this meeting.</p>
+                <div>
+                  <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                  <select id="category"
+                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                    <option selected="">Select Time</option>
+                    <option value="TV">Feb.10th @11AM-12PM</option>
+                    <option value="PC">Feb.11th @9AM-10AM</option>
+                    <option value="GA">Feb.12th @9AM-10AM</option>
+                  </select>
+                </div>
+                <a href="waiting-schedule.html" type="button" id="continueButton"
+                  class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                </a>
               </div>
               <div data-popper-arrow></div>
             </div>
@@ -259,6 +285,19 @@
               <div class="px-3 py-2">
                 <p><b>Sunday, February 14th @1PM-2PM</b></p>
                 <p>Notes: Prepare slides before this meeting.</p>
+                <div>
+                  <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                  <select id="category"
+                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                    <option selected="">Select Time</option>
+                    <option value="TV">Feb.10th @11AM-12PM</option>
+                    <option value="PC">Feb.11th @9AM-10AM</option>
+                    <option value="GA">Feb.12th @9AM-10AM</option>
+                  </select>
+                </div>
+                <a href="waiting-schedule.html" type="button" id="continueButton"
+                  class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                </a>
               </div>
               <div data-popper-arrow></div>
             </div>
@@ -356,6 +395,19 @@
               <div class="px-3 py-2">
                 <p><b>Thursday, February 13th @5PM-6PM</b></p>
                 <p>Notes: Prepare slides before this meeting.</p>
+                <div>
+                  <label for="category" class="block mt-2 mb-2">Alternate Times:</label>
+                  <select id="category"
+                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary-500 dark:focus:border-primary-500">
+                    <option selected="">Select Time</option>
+                    <option value="TV">Feb.10th @11AM-12PM</option>
+                    <option value="PC">Feb.11th @9AM-10AM</option>
+                    <option value="GA">Feb.12th @9AM-10AM</option>
+                  </select>
+                </div>
+                <a href="waiting-schedule.html" type="button" id="continueButton"
+                  class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-2.5 py-1 mb-2 mt-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Save
+                </a>
               </div>
               <div data-popper-arrow></div>
             </div>
@@ -501,6 +553,12 @@
             </tr>
           </tbody>
         </table>
+      </div>
+
+      <div class="flex justify-center">
+        <a href="dashboard.html" type="button" id="continueButton"
+          class="mt-8 focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900">Finalize
+        </a>
       </div>
 
       <h1 class="text-lg md:text-4xl mt-10 border-b p-4">Invited Users:</h1>

--- a/waiting-schedule.html
+++ b/waiting-schedule.html
@@ -1,0 +1,615 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <title>Finalized Schedule</title>
+</head>
+
+<body>
+  <main>
+    <div class="m-8 p-8 w-full bg-white flex justify-right items-right">
+      <button data-drawer-target="logo-sidebar" data-drawer-toggle="logo-sidebar" aria-controls="logo-sidebar" type="button"
+        class="inline-flex items-center p-4 text-sm text-gray-500 rounded-lg sm:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600">
+        <span class="sr-only">Open sidebar</span>
+        <svg class="w-6 h-6" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+          <path clip-rule="evenodd" fill-rule="evenodd"
+            d="M2 4.75A.75.75 0 012.75 4h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 4.75zm0 10.5a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM2 10a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 10z">
+          </path>
+        </svg>
+      </button>
+    </div>
+
+    <aside id="logo-sidebar" class="fixed top-0 left-0 z-40 w-64 h-screen transition-transform -translate-x-full sm:translate-x-0" aria-label="Sidebar">
+      <div class="h-full px-3 py-4 overflow-y-auto bg-gray-50 dark:bg-gray-800">
+        <a href="dashboard.html" class="flex items-center ps-2.5 mb-5">
+          <img src="https://flowbite.com/docs/images/logo.svg" class="h-6 me-3 sm:h-7" alt="Flowbite Logo" />
+          <span class="self-center text-xl font-semibold whitespace-nowrap dark:text-white">1on1</span>
+        </a>
+        <ul class="space-y-2 font-medium">
+          <li class="pt-8">
+            <a type="button"
+              class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-full text-sm px-5 py-2.5 text-center inline-flex items-center">
+              Create Calendar
+              <svg class="rtl:rotate-180 w-3.5 h-3.5 ms-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
+                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 5h12m0 0L9 1m4 4L9 9" />
+              </svg>
+            </a>
+          </li>
+          <li>
+            <a href="dashboard.html" class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+              <svg class="flex-shrink-0 w-5 h-5 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 22 21">
+                <path d="M16.975 11H10V4.025a1 1 0 0 0-1.066-.998 8.5 8.5 0 1 0 9.039 9.039.999.999 0 0 0-1-1.066h.002Z" />
+                <path d="M12.5 0c-.157 0-.311.01-.565.027A1 1 0 0 0 11 1.02V10h8.975a1 1 0 0 0 1-.935c.013-.188.028-.374.028-.565A8.51 8.51 0 0 0 12.5 0Z" />
+              </svg>
+              <span class="flex-1 ms-3 whitespace-nowrap">Dashboard</span>
+            </a>
+          </li>
+
+          <li>
+            <a href="contact.html" class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+              <svg class="flex-shrink-0 w-5 h-5 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 18">
+                <path
+                  d="M14 2a3.963 3.963 0 0 0-1.4.267 6.439 6.439 0 0 1-1.331 6.638A4 4 0 1 0 14 2Zm1 9h-1.264A6.957 6.957 0 0 1 15 15v2a2.97 2.97 0 0 1-.184 1H19a1 1 0 0 0 1-1v-1a5.006 5.006 0 0 0-5-5ZM6.5 9a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9ZM8 10H5a5.006 5.006 0 0 0-5 5v2a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-2a5.006 5.006 0 0 0-5-5Z" />
+              </svg>
+              <span class="flex-1 ms-3 whitespace-nowrap">Contacts</span>
+            </a>
+          </li>
+          <li>
+            <a href="#" class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+              <svg class="flex-shrink-0 w-5 h-5 text-gray-500 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M5 5V.13a2.96 2.96 0 0 0-1.293.749L.879 3.707A2.96 2.96 0 0 0 .13 5H5Z" />
+                <path
+                  d="M6.737 11.061a2.961 2.961 0 0 1 .81-1.515l6.117-6.116A4.839 4.839 0 0 1 16 2.141V2a1.97 1.97 0 0 0-1.933-2H7v5a2 2 0 0 1-2 2H0v11a1.969 1.969 0 0 0 1.933 2h12.134A1.97 1.97 0 0 0 16 18v-3.093l-1.546 1.546c-.413.413-.94.695-1.513.81l-3.4.679a2.947 2.947 0 0 1-1.85-.227 2.96 2.96 0 0 1-1.635-3.257l.681-3.397Z" />
+                <path
+                  d="M8.961 16a.93.93 0 0 0 .189-.019l3.4-.679a.961.961 0 0 0 .49-.263l6.118-6.117a2.884 2.884 0 0 0-4.079-4.078l-6.117 6.117a.96.96 0 0 0-.263.491l-.679 3.4A.961.961 0 0 0 8.961 16Zm7.477-9.8a.958.958 0 0 1 .68-.281.961.961 0 0 1 .682 1.644l-.315.315-1.36-1.36.313-.318Zm-5.911 5.911 4.236-4.236 1.359 1.359-4.236 4.237-1.7.339.341-1.699Z" />
+              </svg>
+              <span class="flex-1 ms-3 whitespace-nowrap">Sign Out</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </aside>
+
+    <div class="p-8 sm:ml-64">
+      <div class="text-left w-full border-b p-4 flex justify-between mb-4 items-center">
+        <h1 class="text-lg md:text-4xl"> 30 Minute Meeting
+          <span class="inline-flex align-middle items-center bg-green-100 text-green-800 text-xs font-medium ml-2.5 px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+            <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+            Finalized
+          </span>
+        </h1>
+        <div class="flex items-center justify-center">
+          <a type="button" id="lastWeekButton" class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-full px-2 py-2 mr-1 ">
+            <svg class="w-5 h-5 text-white " aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 19-7-7 7-7" />
+            </svg> </a>
+          <a type="button" id="nextWeekButton" class="focus:outline-none text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-full px-2 py-2 "> <svg
+              class="w-5 h-5 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 5 7 7-7 7" />
+            </svg> </a>
+        </div>
+      </div>
+      <div class="table-container flex justify-center">
+        <table class="divide-y divide-gray-200 border border-gray-200 shadow-xl sm:rounded-lg min-w-full">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Time
+              </th>
+              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Sun 9
+              </th>
+              <th scope="col" class="px-3  py-3  text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Mon 10
+              </th>
+              <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Tue 11
+              </th>
+              <th scope="col" class="px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Wed 12
+              </th>
+              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200  border border-gray-300">
+                Thu 13
+              </th>
+              <th scope="col" class="px-3 py-3 text-xs font-medium  text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Fri 14
+              </th>
+              <th scope="col" class="px-3 py-3  text-xs font-medium text-gray-500 uppercase tracking-wider text-center bg-gray-200 border border-gray-300">
+                Sat 15
+              </th>
+            </tr>
+          </thead>
+          <tbody class="bg-white">
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                9:00 AM</td>
+              <td rowspan="2" data-popover-target="jim-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM"
+                data-date="Sun 9">Jim</td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Mon 10"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Tue 11"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Wed 12"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Thu 13"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Fri 14"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:00 AM" data-date="Sat 15"></td>
+            </tr>
+            <div data-popover id="jim-popover" role="tooltip"
+              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Jim</h3>
+              </div>
+              <div class="px-3 py-2">
+                <p><b>Sunday, February 9th @9AM-10AM</b></p>
+                <p>Notes: Prepare slides before this meeting.</p>
+              </div>
+              <div data-popper-arrow></div>
+            </div>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Mon 10"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Tue 11"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Wed 12"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Thu 13"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Fri 14"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100" data-time="9:30 AM" data-date="Sat 15"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                10:00 AM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                11:00 AM
+              </td>
+              <td rowspan="2" data-popover-target="peter-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Peter</td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <div data-popover id="peter-popover" role="tooltip"
+              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Peter</h3>
+              </div>
+              <div class="px-3 py-2">
+                <p><b>Sunday, February 9th @11AM-12PM</b></p>
+                <p>Notes: Prepare slides before this meeting.</p>
+              </div>
+              <div data-popper-arrow></div>
+            </div>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                12:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                1:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td rowspan="2" data-popover-target="neil-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Neil</td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <div data-popover id="neil-popover" role="tooltip"
+              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Neil</h3>
+              </div>
+              <div class="px-3 py-2">
+                <p><b>Sunday, February 14th @1PM-2PM</b></p>
+                <p>Notes: Prepare slides before this meeting.</p>
+              </div>
+              <div data-popper-arrow></div>
+            </div>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                2:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                3:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                4:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                5:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td rowspan="2" data-popover-target="bonnie-popover" data-popover-trigger="click" class="selected whitespace-nowrap text-sm text-gray-500 border border-gray-100">Bonnie</td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <div data-popover id="bonnie-popover" role="tooltip"
+              class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800">
+              <div class="px-3 py-2 bg-blue-400 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                <h3 class="font-semibold text-gray-900 dark:text-white">Meeting w/ Bonnie</h3>
+              </div>
+              <div class="px-3 py-2">
+                <p><b>Thursday, February 13th @5PM-6PM</b></p>
+                <p>Notes: Prepare slides before this meeting.</p>
+              </div>
+              <div data-popper-arrow></div>
+            </div>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                6:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                7:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                8:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                9:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                10:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+
+            <tr>
+              <td rowspan="2" class="pr-2 py-4 whitespace-nowrap text-xs font-medium bg-white text-gray-500 text-right">
+                11:00 PM
+              </td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+            <tr>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+              <td class="whitespace-nowrap text-sm text-gray-500 border border-gray-100"></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h1 class="text-lg md:text-4xl mt-10 border-b p-4">Invited Users:</h1>
+      <div id="selectedContacts" class="mt-4 flex flex-col justify-center">
+        <ul role="list" class="max-w-sm divide-y divide-gray-200 dark:divide-gray-700 mx-auto">
+          <li class="py-3 sm:py-4">
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <div class="flex-shrink-0">
+                <img class="w-8 h-8 rounded-full" src="media/profile.jpg" alt="Neil image">
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-gray-900 truncate dark:text-white">
+                  Jim Love
+                </p>
+                <p class="text-sm text-gray-500 truncate dark:text-gray-400">
+                  jim.love@gmail.com
+                </p>
+              </div>
+              <div class="flex flex-col space-y-2">
+                <span class="inline-flex items-center bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+                  <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+                  Confirmed
+                </span>
+              </div>
+            </div>
+          </li>
+          <li class="py-3 sm:py-4">
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <div class="flex-shrink-0">
+                <img class="w-8 h-8 rounded-full" src="media/profile.jpg" alt="Neil image">
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-gray-900 truncate dark:text-white">
+                  Peter Parker
+                </p>
+                <p class="text-sm text-gray-500 truncate dark:text-gray-400">
+                  peter.parker@spiderman.web
+                </p>
+              </div>
+              <div class="flex flex-col space-y-2">
+                <span class="inline-flex items-center bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+                  <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+                  Confirmed
+                </span>
+              </div>
+            </div>
+          </li>
+          <li class="py-3 sm:py-4">
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <div class="flex-shrink-0">
+                <img class="w-8 h-8 rounded-full" src="media/profile.jpg" alt="Neil image">
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-gray-900 truncate dark:text-white">
+                  Neil Sims
+                </p>
+                <p class="text-sm text-gray-500 truncate dark:text-gray-400">
+                  neil.sims@gmail.com
+                </p>
+              </div>
+              <span class="inline-flex items-center bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+                <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+                Confirmed
+              </span>
+            </div>
+          </li>
+          <li class="py-3 sm:py-4">
+            <div class="flex items-center space-x-3 rtl:space-x-reverse">
+              <div class="flex-shrink-0">
+                <img class="w-8 h-8 rounded-full" src="media/profile.jpg" alt="Neil image">
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-gray-900 truncate dark:text-white">
+                  Bonnie Green
+                </p>
+                <p class="text-sm text-gray-500 truncate dark:text-gray-400">
+                  bonnie.green@gmail.com
+                </p>
+              </div>
+              <div class="flex flex-col space-y-2">
+                <span class="inline-flex items-center bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full dark:bg-green-900 dark:text-green-300">
+                  <span class="w-2 h-2 me-1 bg-green-500 rounded-full"></span>
+                  Confirmed
+                </span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+    </div>
+  </main>
+  <footer class="bg-white rounded-lg dark:bg-gray-900 p-8 sm:ml-64">
+    <div class="w-full max-w-screen-xl mx-auto p-4 md:py-8">
+      <hr class="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8" />
+      <span class="block text-sm text-gray-500 sm:text-center dark:text-gray-400">©
+        2024 <a href="#" class="hover:underline">1on1™</a>. All Rights
+        Reserved.</span>
+    </div>
+  </footer>
+</body>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js"></script>
+<script src="calendar.js"></script>
+<script>
+  function sendReminder(name) {
+    alert("Reminder sent to " + name);
+  }
+
+</script>
+
+</html>


### PR DESCRIPTION
- When calendar is finalized, it shows a green finalized icon on top.
<img width="1539" alt="Screen Shot 2024-02-10 at 4 54 03 PM" src="https://github.com/taeukkang09/1on1/assets/50894688/80abfee4-4e98-4324-8fc1-ea8f6e1149ff">


- Popup appears when a meeting is clicked on the calendar, showing the name and date. On the finalized page, it does not show alternate meeting times because the user can't change meeting times of already finalized calendars.
<img width="1275" alt="Screen Shot 2024-02-10 at 4 54 51 PM" src="https://github.com/taeukkang09/1on1/assets/50894688/1c56dea0-9920-4a1a-b007-91f4b7fb390b">


- On the "Waiting to Finalize" page, it shows a yellow icon on top. To show the 3 different suggested calendars, there are option tabs which show the 3 different calendars when clicked. 
<img width="1540" alt="Screen Shot 2024-02-10 at 4 56 49 PM" src="https://github.com/taeukkang09/1on1/assets/50894688/e758271a-c98c-45e5-9b71-486b155d5087">


- When a meeting time is clicked, it shows the same info as before, but also an option to choose alternate meeting times from a dropdown list. 
<img width="1259" alt="Screen Shot 2024-02-10 at 4 58 25 PM" src="https://github.com/taeukkang09/1on1/assets/50894688/246639f3-c529-4b20-9042-829c68457182">

<img width="423" alt="Screen Shot 2024-02-10 at 4 59 07 PM" src="https://github.com/taeukkang09/1on1/assets/50894688/641ccc11-9cb9-4349-9bfa-3c348395a28a">


- When the user selects a suggested schedule, makes changes, and clicks the "Finalize Calendar" button, it shows a popup "Success" modal, and redirects to the "finalized-calendar" page. 
<img width="1526" alt="Screen Shot 2024-02-10 at 5 00 45 PM" src="https://github.com/taeukkang09/1on1/assets/50894688/4cfb1918-7756-4c0a-8db3-25c79ca703ea">
